### PR TITLE
Re-introduce hash collision by ignoring MPI flavor

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,11 @@ mpi:
   - nompi
   - mpich
   - openmpi
+# This is to make sure "mpi" above is *NOT* used to compute the package hash. For "cutensornet"
+# the non-colliding hashes are acceptable (though not preferred if avoidable) because we
+# wanted 3 flavors of "cutensornet" generated. But, for the "cuquantum" metapackage if the
+# hashes are not colliding we'd also generate 3 packages (one for each "mpi" flavor), despite
+# it has nothing to do with MPI. We better make sure we have colliding hashes, so that only
+# 1 unique upload would be done by the CI.
+ignore_version:
+  - mpi

--- a/recipe/cutn_run_test.sh
+++ b/recipe/cutn_run_test.sh
@@ -11,7 +11,7 @@ test -f $PREFIX/lib/libcutensornet.so
 ${GCC} test_load_elf.c -std=c99 -Werror -ldl -o test_load_elf
 ./test_load_elf $PREFIX/lib/libcutensornet.so
 
-if [[ $mpi == "openmpi" ]]; then
+if [[ -f "$PREFIX/lib/libmpi.so" ]]; then
     EXTRA_LIBS="$PREFIX/lib/libmpi.so"
 else
     EXTRA_LIBS=""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set cutn_version = "2.0.0" %}
 
 # prioritize nompi variant via build number
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 {% if mpi == 'nompi' %}
 {% set cutn_build = build_num + 101 %}
 {% else %}
@@ -19,7 +19,7 @@
 {% endif %}
 
 package:
-  name: cuquantum
+  name: cuquantum-sdk  # dummy
   version: {{ version }}
 
 source:
@@ -37,19 +37,15 @@ source:
 
 build:
   number: {{ build_num }}
+  skip: true  # [not linux or cuda_compiler_version != "11.2"]
 
 outputs:
 
-  # Note: the value of "mpi" would be used to compute the package hash, so despite this
-  # metapackage does not care about MPI, it would still have 3 flavors built and uploaded
-  # due to non-colliding hashes. Ideally, this could be avoided by using jinja (or
-  # selector) to do conditional build (or skip), but either conda-build or conda-smithy
-  # has a bug that makes it not working.
   - name: cuquantum
     version: {{ version }}
     build:
       number: {{ build_num }}
-      skip: true  # [win or cuda_compiler_version != "11.2"]
+      skip: true  # [not linux or cuda_compiler_version != "11.2"]
     requirements:
       build:
       host:
@@ -64,7 +60,7 @@ outputs:
     version: {{ cusv_version }}
     build:
       number: {{ build_num }}
-      skip: true  # [win or cuda_compiler_version != "11.2"]
+      skip: true  # [not linux or cuda_compiler_version != "11.2"]
       script:
         - mkdir -p $PREFIX/include                                            # [linux]
         - mv include/custatevec.h $PREFIX/include/                            # [linux]
@@ -131,7 +127,7 @@ outputs:
     build:
       number: {{ cutn_build }}
       string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ cutn_build }}"
-      skip: true  # [win or cuda_compiler_version != "11.2"]
+      skip: true  # [not linux or cuda_compiler_version != "11.2"]
       script:
         - mkdir -p $PREFIX/include                                            # [linux]
         - mv include/cutensornet* $PREFIX/include/                            # [linux]
@@ -217,7 +213,7 @@ outputs:
     build:
       #number: {{ build_num }}
       number: 0  # TODO: revert me
-      skip: True  # [win or cuda_compiler_version != "11.2" or py < 38]
+      skip: true  # [not linux or cuda_compiler_version != "11.2"]
       script_env:
         - CUQUANTUM_ROOT=$PREFIX
         - CUTENSOR_ROOT=$PREFIX


### PR DESCRIPTION
It turns out that the conda-build bug affects whether the `mpi` env var is defined at the test stage. By not using it, we circumvent the bug. For how the hash collision works, see the inline comments.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
